### PR TITLE
fix: Alteração da classe veiculo para abstract

### DIFF
--- a/Veiculo.ts
+++ b/Veiculo.ts
@@ -1,4 +1,4 @@
-export class Veiculo {
+export abstract class Veiculo {
   public disponibilidade = true;
   public tipo: string = "";
 


### PR DESCRIPTION
Mudança da classe veiculo para abstrata para que não possa ser instanciada diretamente, uma vez que ela é a base para os objetos carro e moto, mas não é usada ou necessita de instancia direta dela.